### PR TITLE
bump branch-deploy action

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: branch-deploy
         id: branch-deploy
-        uses: GrantBirki/branch-deploy@5d7ea46552d858242fa4bf16625e9f29b1ee1b63 # pin@v1.4.2
+        uses: GrantBirki/branch-deploy@35cce77afd4fafcda2d28c861fc85cddbcec67f0 # pin@v1.5.0
         
       # Check out the ref from the output of the IssueOps command
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3.0.2


### PR DESCRIPTION
This PR bumps the version of the `branch-deploy` Action to version v1.5.0 which requires all branches to be up-to-date before a branch deploy can continue. By default, it will warn users via a PR comment and exit